### PR TITLE
Fix typo "raylip" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install raylib-py
 or
 
 ```
-python -m pip install raylip-py
+python -m pip install raylib-py
 ```
 
 or (with Python3.7 launcher with multiple versions installed)


### PR DESCRIPTION
I noticed this issue when I blindly copy-and-pasted that line into my terminal.

I should probably be a bit more careful with random terminal commands I find online...