### PR TITLE
fix draw_line_ex function

### DIFF
--- a/raylibpy/__init__.py
+++ b/raylibpy/__init__.py
@@ -3477,7 +3477,7 @@ _rl.DrawLineEx.argtypes = [Vector2, Vector2, Float, Color]
 _rl.DrawLineEx.restype = None
 def draw_line_ex(start_pos: Union[Vector2, Seq], end_pos: Union[Vector2, Seq], thick: float, color: Union[Color, Seq]) -> None:
 	"""Draw a line defining thickness"""
-	return _rl.DrawLineEx(_vec2(start_pos), _vec2(end_pos), _float(_vec2(thick)), _color(color))
+	return _rl.DrawLineEx(_vec2(start_pos), _vec2(end_pos), _float(thick), _color(color))
 
 
 _rl.DrawLineBezier.argtypes = [Vector2, Vector2, Float, Color]


### PR DESCRIPTION
It looks like there was a typo in the `draw_line_ex` function that made it unusable. It tried to coerce the `thick` parameter (a float) into a vec2, then back into a float, which always fails and throws an exception.

In the meantime, I've been redefining the function as the following lambda without the problematic cast
```python
import raylibpy as rl
rl.draw_line_ex = lambda start_pos, end_pos, thick, color: rl._rl.DrawLineEx(rl._vec2(start_pos), rl._vec2(end_pos), rl._float(thick), rl._color(color))
```