### PR TITLE
Corrected Vector3 to Vector4

### DIFF
--- a/raylibpy/__init__.py
+++ b/raylibpy/__init__.py
@@ -859,7 +859,7 @@ def _vec3(seq: Sequence[Number]) -> 'Vector3':
 	return Vector3(_float(x), _float(y), _float(z))
 
 
-def _vec4(seq: Sequence[Number]) -> 'Vector3':
+def _vec4(seq: Sequence[Number]) -> 'Vector4':
 	if isinstance(seq, Vector4):
 		return seq
 	x, y, z, w = seq


### PR DESCRIPTION
The `_vec4` function had the incorrect type hint of `'Vector3'` I have changed this to `'Vector4'`