### PR TITLE
Raylibpy 3.7: Support linux + Toggle external raylib library

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,16 @@ py-3.x-32 -m pip install raylib-py
 
 > Note that the minimum Python version tested is 3.4. Please, let me know if you're able to run it in Python33.
 
-_raylib-py_ comes with 32bit binaries for Windows, Mac and Linux, but you're not required to use these. If you have a custom _raylib_ _**dll**_, _**dylib**_ or _**so**_ binary, make sure to set a PATH indicating the directory it is located:
+_raylib-py_ comes with 32bit binaries for Windows, Mac and Linux, but you're not required to use these.
+If you have an existing _raylib_ _**dll**_, _**dylib**_ or _**so**_ binary, you can set the environment variable
+"USE_EXTERNAL_RAYLIB" to any value (it just has to exist) and _raylib-py_ will fallback to using your operating
+sytems mechanism of loading libraries.
 
 ```python
 import os
 
-# set the path before raylib is imported.
-os.environ["RAYLIB_BIN_PATH"] = "path/to/the/binary"
-os.environ["RAYLIB_BIN_FILENAME"] = "custom-raylib-name.so"
+# specify that we should load raylib from the system instead
+os.environ["USE_EXTERNAL_RAYLIB"] = True
 
 import raylibpy
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ _raylib-py_ uses type [annotations](https://www.python.org/dev/peps/pep-3107/#id
 that supports it is required.
 
 Some Python versions may not have [enum](https://pypi.org/project/enum/)
-and/or [typings](https://pypi.org/project/typing/) modules as part of the standard library, wich are required. These are
+and/or [typings](https://pypi.org/project/typing/) modules as part of the standard library, which are required. These are
 installed automatically by pip.
 
 ### Installing
@@ -52,6 +52,20 @@ py-3.x-32 -m pip install raylib-py
 ```
 
 > Note that the minimum Python version tested is 3.4. Please, let me know if you're able to run it in Python33.
+
+_raylib-py_ comes with 32bit binaries for Windows, Mac and Linux, but you're not required to use these. If you have a custom _raylib_ _**dll**_, _**dylib**_ or _**so**_ binary, make sure to set a PATH indicating the directory it is located:
+
+```python
+import os
+
+# set the path before raylib is imported.
+os.environ["RAYLIB_BIN_PATH"] = "path/to/the/binary"
+os.environ["RAYLIB_BIN_FILENAME"] = "custom-raylib-name.so"
+
+import raylibpy
+
+# let the fun begin.
+```
 
 ## Tests
 
@@ -287,4 +301,3 @@ _raylib-py_ (and _raylib_) is licensed under an unmodified zlib/libpng license, 
 * Inspiration
 * etc
 -->
-

--- a/raylibpy/__init__.py
+++ b/raylibpy/__init__.py
@@ -14,53 +14,50 @@ __all__ = [
 
 # region CDLLEX
 
-DONT_RESOLVE_DLL_REFERENCES = 0x00000001
-LOAD_LIBRARY_AS_DATAFILE = 0x00000002
-LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
-LOAD_IGNORE_CODE_AUTHZ_LEVEL = 0x00000010  # NT 6.1
-LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x00000020  # NT 6.0
-LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE = 0x00000040  # NT 6.0
+if sys.platform == 'win32':
+	DONT_RESOLVE_DLL_REFERENCES = 0x00000001
+	LOAD_LIBRARY_AS_DATAFILE = 0x00000002
+	LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
+	LOAD_IGNORE_CODE_AUTHZ_LEVEL = 0x00000010  # NT 6.1
+	LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x00000020  # NT 6.0
+	LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE = 0x00000040  # NT 6.0
 
-# These cannot be combined with LOAD_WITH_ALTERED_SEARCH_PATH.
-# Install update KB2533623 for NT 6.0 & 6.1.
-LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
-LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x00000200
-LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400
-LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
-LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
+	# These cannot be combined with LOAD_WITH_ALTERED_SEARCH_PATH.
+	# Install update KB2533623 for NT 6.0 & 6.1.
+	LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
+	LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x00000200
+	LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400
+	LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
+	LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
 
-kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+	kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
 
+	def check_bool(result, func, args):
+	    if not result:
+	        raise ctypes.WinError(ctypes.get_last_error())
+	    return args
 
-def check_bool(result, func, args):
-    if not result:
-        raise ctypes.WinError(ctypes.get_last_error())
-    return args
+	kernel32.LoadLibraryExW.errcheck = check_bool
+	kernel32.LoadLibraryExW.restype = wintypes.HMODULE
+	kernel32.LoadLibraryExW.argtypes = (wintypes.LPCWSTR,
+	                                    wintypes.HANDLE,
+	                                    wintypes.DWORD)
 
+	class WinDLLEx(ctypes.WinDLL):
+	    def __init__(self, name, mode=0, handle=None,
+	                 use_errno=False, use_last_error=True):
+	        if handle is None:
+	            handle = kernel32.LoadLibraryExW(name, None, mode)
+	        super(WinDLLEx, self).__init__(name, mode, handle,
+	                                       use_errno, use_last_error)
 
-kernel32.LoadLibraryExW.errcheck = check_bool
-kernel32.LoadLibraryExW.restype = wintypes.HMODULE
-kernel32.LoadLibraryExW.argtypes = (wintypes.LPCWSTR,
-                                    wintypes.HANDLE,
-                                    wintypes.DWORD)
-
-
-class CDLLEx(ctypes.CDLL):
-    def __init__(self, name, mode=0, handle=None,
-                 use_errno=True, use_last_error=False):
-        if handle is None:
-            handle = kernel32.LoadLibraryExW(name, None, mode)
-        super(CDLLEx, self).__init__(name, mode, handle,
-                                     use_errno, use_last_error)
-
-
-class WinDLLEx(ctypes.WinDLL):
-    def __init__(self, name, mode=0, handle=None,
-                 use_errno=False, use_last_error=True):
-        if handle is None:
-            handle = kernel32.LoadLibraryExW(name, None, mode)
-        super(WinDLLEx, self).__init__(name, mode, handle,
-                                       use_errno, use_last_error)
+	class CDLLEx(ctypes.CDLL):
+	    def __init__(self, name, mode=0, handle=None,
+	                 use_errno=True, use_last_error=False):
+	        if handle is None:
+	            handle = kernel32.LoadLibraryExW(name, None, mode)
+	        super(CDLLEx, self).__init__(name, mode, handle,
+	                                     use_errno, use_last_error)
 
 
 # endregion (cdllex)

--- a/raylibpy/__init__.py
+++ b/raylibpy/__init__.py
@@ -7,7 +7,6 @@ from ctypes import CDLL, wintypes
 
 __all__ = [
     '_rl',
-    'CDLLEx',
 ]
 
 # region LIBRARY LOADING

--- a/raylibpy/__init__.py
+++ b/raylibpy/__init__.py
@@ -15,93 +15,93 @@ __all__ = [
 # region CDLLEX
 
 if sys.platform == 'win32':
-	DONT_RESOLVE_DLL_REFERENCES = 0x00000001
-	LOAD_LIBRARY_AS_DATAFILE = 0x00000002
-	LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
-	LOAD_IGNORE_CODE_AUTHZ_LEVEL = 0x00000010  # NT 6.1
-	LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x00000020  # NT 6.0
-	LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE = 0x00000040  # NT 6.0
+    DONT_RESOLVE_DLL_REFERENCES = 0x00000001
+    LOAD_LIBRARY_AS_DATAFILE = 0x00000002
+    LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
+    LOAD_IGNORE_CODE_AUTHZ_LEVEL = 0x00000010  # NT 6.1
+    LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x00000020  # NT 6.0
+    LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE = 0x00000040  # NT 6.0
 
-	# These cannot be combined with LOAD_WITH_ALTERED_SEARCH_PATH.
-	# Install update KB2533623 for NT 6.0 & 6.1.
-	LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
-	LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x00000200
-	LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400
-	LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
-	LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
+    # These cannot be combined with LOAD_WITH_ALTERED_SEARCH_PATH.
+    # Install update KB2533623 for NT 6.0 & 6.1.
+    LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
+    LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x00000200
+    LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400
+    LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
+    LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
 
-	kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
 
-	def check_bool(result, func, args):
-	    if not result:
-	        raise ctypes.WinError(ctypes.get_last_error())
-	    return args
+    def check_bool(result, func, args):
+        if not result:
+            raise ctypes.WinError(ctypes.get_last_error())
+        return args
 
-	kernel32.LoadLibraryExW.errcheck = check_bool
-	kernel32.LoadLibraryExW.restype = wintypes.HMODULE
-	kernel32.LoadLibraryExW.argtypes = (wintypes.LPCWSTR,
-	                                    wintypes.HANDLE,
-	                                    wintypes.DWORD)
+    kernel32.LoadLibraryExW.errcheck = check_bool
+    kernel32.LoadLibraryExW.restype = wintypes.HMODULE
+    kernel32.LoadLibraryExW.argtypes = (wintypes.LPCWSTR,
+                                        wintypes.HANDLE,
+                                        wintypes.DWORD)
 
-	class WinDLLEx(ctypes.WinDLL):
-	    def __init__(self, name, mode=0, handle=None,
-	                 use_errno=False, use_last_error=True):
-	        if handle is None:
-	            handle = kernel32.LoadLibraryExW(name, None, mode)
-	        super(WinDLLEx, self).__init__(name, mode, handle,
-	                                       use_errno, use_last_error)
+    class WinDLLEx(ctypes.WinDLL):
+        def __init__(self, name, mode=0, handle=None,
+                     use_errno=False, use_last_error=True):
+            if handle is None:
+                handle = kernel32.LoadLibraryExW(name, None, mode)
+            super(WinDLLEx, self).__init__(name, mode, handle,
+                                           use_errno, use_last_error)
 
-	class CDLLEx(ctypes.CDLL):
-	    def __init__(self, name, mode=0, handle=None,
-	                 use_errno=True, use_last_error=False):
-	        if handle is None:
-	            handle = kernel32.LoadLibraryExW(name, None, mode)
-	        super(CDLLEx, self).__init__(name, mode, handle,
-	                                     use_errno, use_last_error)
+    class CDLLEx(ctypes.CDLL):
+        def __init__(self, name, mode=0, handle=None,
+                     use_errno=True, use_last_error=False):
+            if handle is None:
+                handle = kernel32.LoadLibraryExW(name, None, mode)
+            super(CDLLEx, self).__init__(name, mode, handle,
+                                         use_errno, use_last_error)
 
 
 # endregion (cdllex)
 
 
 def raylib_so_paths():
-	'''Return a list of full paths to try and load the shared library from
-	'''
-	def so_paths():
-		main_mod = sys.modules['__main__']
-		running_from_repl = '__file__' not in dir(main_mod)
-		return filter(None, [
-			os.environ.get('RAYLIB_BIN_PATH') if 'RAYLIB_BIN_PATH' in os.environ else None,
-			os.path.join(os.path.dirname(__file__), 'bin'),
-			os.path.join(os.path.dirname(main_mod.__file__), 'bin') if not running_from_repl else None,
-		])
-	def so_names():
-		lib_filenames = {
-		    'win32': ['raylib.dll', 'libraylib.dll', 'libraylib_shared.dll'],
-		    'linux': ['libraylib.so.3.7.0', 'libraylib.so.370', 'libraylib.so'],
-		    'darwin': ['libraylib.3.7.0.dylib', 'libraylib.dylib.370', 'libraylib.dylib'],
-		}
-		return filter(None, [
-			os.environ.get('RAYLIB_BIN_FILENAME'),
-			*lib_filenames[sys.platform]
-		])
-	def join_paths(paths):
-		return os.path.join(*paths)
+    '''Return a list of full paths to try and load the shared library from
+    '''
+    def so_paths():
+        main_mod = sys.modules['__main__']
+        running_from_repl = '__file__' not in dir(main_mod)
+        return filter(None, [
+            os.environ.get('RAYLIB_BIN_PATH') if 'RAYLIB_BIN_PATH' in os.environ else None,
+            os.path.join(os.path.dirname(__file__), 'bin'),
+            os.path.join(os.path.dirname(main_mod.__file__), 'bin') if not running_from_repl else None,
+        ])
+    def so_names():
+        lib_filenames = {
+            'win32': ['raylib.dll', 'libraylib.dll', 'libraylib_shared.dll'],
+            'linux': ['libraylib.so.3.7.0', 'libraylib.so.370', 'libraylib.so'],
+            'darwin': ['libraylib.3.7.0.dylib', 'libraylib.dylib.370', 'libraylib.dylib'],
+        }
+        return filter(None, [
+            os.environ.get('RAYLIB_BIN_FILENAME'),
+            *lib_filenames[sys.platform]
+        ])
+    def join_paths(paths):
+        return os.path.join(*paths)
 
-	paths = itertools.product(so_paths(), so_names())
-	return list(map(join_paths, paths))
+    paths = itertools.product(so_paths(), so_names())
+    return list(map(join_paths, paths))
 
 def find_raylib_so(raylib_paths):
-	'''Given a list of possible paths, finds the first valid one.
-	If no paths are valid, throws a RuntimeError.
-	'''
-	valid_paths = list(filter(lambda path: os.path.isfile(path), raylib_paths))
-	if len(valid_paths):
-		return valid_paths[0]
+    '''Given a list of possible paths, finds the first valid one.
+    If no paths are valid, throws a RuntimeError.
+    '''
+    valid_paths = list(filter(lambda path: os.path.isfile(path), raylib_paths))
+    if len(valid_paths):
+        return valid_paths[0]
 
-	raise RuntimeError((
-		'Cannot find Raylib shared object in these search paths:\n'
-		'{}'
-	).format('\n'.join(raylib_paths)))
+    raise RuntimeError((
+        'Cannot find Raylib shared object in these search paths:\n'
+        '{}'
+    ).format('\n'.join(raylib_paths)))
 
 
 


### PR DESCRIPTION
Gets raylib 3.7 _almost_ working on Linux (another PR is coming for a separate fix)

Changes:
* The ctypes import were pulling in win32 only symbols. Wrap this in an 'if windows' scope.
* The ability to provide custom library paths is important for OS such as NixOS. So lets reinstate the older logic that supported passing in a library path via environment variable "RAYLIB_BIN_PATH".
* Also support a series of path names being provided which let us search multiple locations.
* Add a new environment variable "RAYLIB_BIN_FILENAME" which lets us specify the filename to load for the library. (This isn't required for Nix but I felt that it might be of use)
* Corrected type in README.md ("wich" -> "which").