### PR TITLE
Raylibpy 3.7: Correct raylib.dll filename on Windows to fix loading

### DIFF
--- a/raylibpy/__init__.py
+++ b/raylibpy/__init__.py
@@ -72,7 +72,7 @@ def raylib_library_path():
     def so_name():
         '''Returns the appropriate for the library on the current platform.'''
         lib_filenames = {
-            'Windows': 'libraylib.dll',
+            'Windows': 'raylib.dll',
             'Linux': 'libraylib.so.3.7.0',
             'Darwin': 'libraylib.3.7.0.dylib',
         }


### PR DESCRIPTION
#31 Updated the dll loading to work with Linux.
This PR incorrectly changed the name of the Windows DLL to be loaded.

As can be seen here: https://github.com/overdev/raylib-py/blob/raylibpy-3.7/raylibpy/bin/raylib.dll
The filename should be 'raylib.dll'.

This reverts a small part of that PR to again work on Windows.